### PR TITLE
🪲 [Fix]: Nightly-Run workflow reference

### DIFF
--- a/.github/workflows/Nightly-Run.yml
+++ b/.github/workflows/Nightly-Run.yml
@@ -1,4 +1,4 @@
-name: Nightly run
+name: Nightly Run
 
 on:
   workflow_dispatch:
@@ -6,12 +6,11 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
-  contents: write
-  issues: write
+  contents: read
   pull-requests: write
   statuses: write
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@v3
+    uses: PSModule/Process-PSModule/.github/workflows/CI.yml@v3
     secrets: inherit


### PR DESCRIPTION
## Description

- Fix Nightly-Run workflow reference, should point to CI.yml and not need additional permissions to run.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
