### PR TITLE
🪲 [Fix]: Fix linter settings and docs

### DIFF
--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,12 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/PSModule.yml
+++ b/.github/PSModule.yml
@@ -19,3 +19,13 @@ Test:
 # Build:
 #   Docs:
 #     Skip: true
+
+Linter:
+  env:
+    VALIDATE_BIOME_FORMAT: false
+    VALIDATE_BIOME_LINT: false
+    VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
+    VALIDATE_JSCPD: false
+    VALIDATE_JSON_PRETTIER: false
+    VALIDATE_MARKDOWN_PRETTIER: false
+    VALIDATE_YAML_PRETTIER: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -8,18 +8,19 @@
 ###############
 # Rules by id #
 ###############
-MD004: false                  # Unordered list style
+MD004: false # Unordered list style
 MD007:
-  indent: 2                   # Unordered list indentation
+  indent: 2 # Unordered list indentation
 MD013:
-  line_length: 808            # Line length
+  line_length: 808 # Line length
+MD024: false # no-duplicate-heading, INPUTS and OUTPUTS _can_ be the same item
 MD026:
-  punctuation: ".,;:!。，；:"  # List of not allowed
-MD029: false                  # Ordered list item prefix
-MD033: false                  # Allow inline HTML
-MD036: false                  # Emphasis used instead of a heading
+  punctuation: '.,;:!。，；:' # List of not allowed
+MD029: false # Ordered list item prefix
+MD033: false # Allow inline HTML
+MD036: false # Emphasis used instead of a heading
 
 #################
 # Rules by tags #
 #################
-blank_lines: false  # Error on blank lines
+blank_lines: false # Error on blank lines

--- a/src/functions/public/Invoke-Retry.ps1
+++ b/src/functions/public/Invoke-Retry.ps1
@@ -9,9 +9,13 @@
         If a catch scriptblock is provided, it will run that scriptblock if the scriptblock fails.
 
         .EXAMPLE
+        ```pwsh
         Retry -Count 5 -Delay 5 -Run {
             Invoke-RestMethod -Uri 'https://api.myip.com/'
         }
+        ```
+
+        Retries an API call 5 times with 5 reconds delay.
     #>
     [CmdletBinding()]
     [Alias('Retry')]


### PR DESCRIPTION
This pull request introduces several configuration improvements for linting and documentation, as well as a minor enhancement to the `Invoke-Retry.ps1` function documentation. The main focus is on making linting more configurable and improving code clarity.

Configuration and Linting Improvements:
* Added a `Linter` section to `.github/PSModule.yml` to allow environment-based toggling of various validation checks, making it easier to control which linters are run in CI.
* Updated `.github/linters/.markdown-lint.yml` to disable the `MD024` rule (no duplicate headings) and made a minor formatting fix for the `MD026` punctuation rule. This allows INPUTS and OUTPUTS to share headings and improves markdown linting flexibility.

Documentation Enhancement:
* Improved the example in the `Invoke-Retry.ps1` function by formatting it as a PowerShell code block and clarifying the example description.